### PR TITLE
Implement summarise()

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -6,4 +6,5 @@ check_transmute_args <- dplyr:::check_transmute_args
 count_regroups <- dplyr:::count_regroups
 dplyr_error_call <- dplyr:::dplyr_error_call
 dplyr_quosures <- dplyr:::dplyr_quosures
+eval_select_by <- dplyr:::eval_select_by
 some <- dplyr:::some

--- a/patch/summarise.patch
+++ b/patch/summarise.patch
@@ -1,15 +1,34 @@
 diff --git b/R/summarise.R a/R/summarise.R
-index 440e8d7..a10029b 100644
+index 440e8d7..97e36d2 100644
 --- b/R/summarise.R
 +++ a/R/summarise.R
-@@ -4,8 +4,8 @@
+@@ -4,8 +4,27 @@
  summarise.duckplyr_df <- function(.data, ..., .by = NULL, .groups = NULL) {
    # Our implementation
    force(.data)
 -  out <- NextMethod()
 -  out <- dplyr_reconstruct(out, .data)
-+  out <- NextMethod(.by = {{ .by }})
-+  out <- as_duckplyr_df(out)
++
++  # Ensure `summarise()` appears in call stack
++  summarise <- rel_try
++  summarise(
++    {
++      rel <- duckdb_rel_from_df(.data)
++      dots <- dplyr_quosures(...)
++      aggregates <- rel_translate_dots(dots, .data)
++      by <- eval_select_by(enquo(.by), .data)
++      groups <- lapply(by, relexpr_reference)
++
++      out_rel <- rel_aggregate(rel, groups, aggregates)
++      out <- rel_to_df(out_rel)
++      class(out) <- class(.data)
++    },
++    fallback = {
++      out <- NextMethod(.by = {{ .by }})
++      out <- as_duckplyr_df(out)
++    }
++  )
++
    return(out)
  
    # dplyr implementation


### PR DESCRIPTION
Two tests currently fail:

``` r
pkgload::load_all()
#> ℹ Loading duckplyr

df <- tibble(g = c(1, 1, 2, 2, 2), x = 1:5)

duckplyr_summarise(df, out = !!1)
#> materializing:
#> ---------------------
#> --- Relation Tree ---
#> ---------------------
#> Aggregate [1.0]
#>   r_dataframe_scan(0x107a96648)
#> 
#> ---------------------
#> -- Result Columns  --
#> ---------------------
#> - out (DOUBLE)
#> 
#> # A tibble: 5 × 1
#>     out
#>   <dbl>
#> 1     1
#> 2     1
#> 3     1
#> 4     1
#> 5     1
summarise(df, out = !!1)
#> # A tibble: 1 × 1
#>     out
#>   <dbl>
#> 1     1

duckplyr_summarise(df, out = !!quo(1))
#> materializing:
#> ---------------------
#> --- Relation Tree ---
#> ---------------------
#> Aggregate [1.0]
#>   r_dataframe_scan(0x125943b48)
#> 
#> ---------------------
#> -- Result Columns  --
#> ---------------------
#> - out (DOUBLE)
#> 
#> # A tibble: 5 × 1
#>     out
#>   <dbl>
#> 1     1
#> 2     1
#> 3     1
#> 4     1
#> 5     1
summarise(df, out = !!quo(1))
#> # A tibble: 1 × 1
#>     out
#>   <dbl>
#> 1     1
```

<sup>Created on 2022-12-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>