### PR TITLE
Benchmarking adjustments

### DIFF
--- a/tools/34-tpch-bench.R
+++ b/tools/34-tpch-bench.R
@@ -2,7 +2,7 @@ pkgload::load_all()
 
 Sys.setenv(DUCKPLYR_FORCE = TRUE)
 Sys.setenv(DUCKPLYR_EXPERIMENTAL = FALSE)
-Sys.setenv(DUCKPLYR_META_GLOBAL = TRUE)
+Sys.setenv(DUCKPLYR_META_SKIP = TRUE)
 
 # Sys.setenv(DUCKPLYR_OUTPUT_ORDER = TRUE)
 
@@ -24,13 +24,13 @@ test_dplyr_q <- head(n = -1, list(
   tpch_04 = tpch_04,
   tpch_05 = tpch_05,
   tpch_06 = tpch_06,
-  # tpch_07 = tpch_07, # string error
-  # tpch_08 = tpch_08, # string error
-  # tpch_09 = tpch_09, # string error
+  tpch_07 = tpch_07, # string error
+  tpch_08 = tpch_08, # string error
+  tpch_09 = tpch_09, # string error
   tpch_10 = tpch_10,
   tpch_11 = tpch_11,
   tpch_12 = tpch_12,
-  # tpch_13 = tpch_13, # takes prohibitively long time
+  tpch_13 = tpch_13, # takes prohibitively long time
   tpch_14 = tpch_14,
   tpch_15 = tpch_15,
   tpch_16 = tpch_16,
@@ -38,8 +38,8 @@ test_dplyr_q <- head(n = -1, list(
   tpch_18 = tpch_18,
   tpch_19 = tpch_19,
   tpch_20 = tpch_20,
-  # tpch_21 = tpch_21, # string error
-  # tpch_22 = tpch_22, # string error
+  tpch_21 = tpch_21, # string error
+  tpch_22 = tpch_22, # string error
   NULL
 ))
 


### PR DESCRIPTION
Adjustments to the benchmarking scripts. Change META_GLOBAL to META skip for better execution results that don't materialize intermediate results.