### PR TITLE
Revert prefix suffix optimizations, revert year extraction

### DIFF
--- a/R/tpch.R
+++ b/R/tpch.R
@@ -27,7 +27,7 @@ tpch_02 <- function() {
 
   p <- part |>
     select_opt(p_partkey, p_type, p_size, p_mfgr) |>
-    filter(p_size == 15, suffix(p_type, "BRASS")) |>
+    filter(p_size == 15, grepl("BRASS$", p_type)) |>
     select_opt(p_partkey, p_mfgr)
 
   psp <- inner_join(na_matches = TPCH_NA_MATCHES, p, ps, by = c("p_partkey" = "ps_partkey"))

--- a/R/tpch.R
+++ b/R/tpch.R
@@ -243,7 +243,7 @@ tpch_07 <- function() {
     mutate(
       supp_nation = n1_name,
       cust_nation = n2_name,
-      l_year = year(l_shipdate),
+      l_year = as.integer(strftime(l_shipdate, "%Y")),
       volume = l_extendedprice * (1 - l_discount)
     ) |>
     select_opt(supp_nation, cust_nation, l_year, volume) |>
@@ -315,7 +315,7 @@ tpch_08 <- function() {
 
   aggr <- all |>
     mutate(
-      o_year = year(o_orderdate),
+      o_year =  as.integer(strftime(o_orderdate, "%Y")),
       volume = l_extendedprice * (1 - l_discount),
       nation = n2_name
     ) |>
@@ -371,7 +371,7 @@ tpch_09 <- function() {
   aggr <- all |>
     mutate(
       nation = n_name,
-      o_year = year(o_orderdate),
+      o_year = as.integer(strftime(o_orderdate, "%Y")),
       amount = l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity
     ) |>
     select_opt(nation, o_year, amount) |>

--- a/R/tpch2.R
+++ b/R/tpch2.R
@@ -86,7 +86,7 @@ tpch_14 <- function() {
     inner_join(na_matches = TPCH_NA_MATCHES, part, by = c("l_partkey" = "p_partkey")) |>
     summarise(
       promo_revenue = 100 * sum(
-        ifelse(prefix(p_type, "PROMO"), l_extendedprice * (1 - l_discount), 0)
+        ifelse(grepl("^PROMO", p_type), l_extendedprice * (1 - l_discount), 0)
       ) / sum(l_extendedprice * (1 - l_discount))
     )
 }
@@ -122,7 +122,7 @@ tpch_16 <- function() {
   part_filtered <- part |>
     filter(
       p_brand != "Brand#45",
-      !prefix(p_type, "MEDIUM POLISHED"),
+      !grepl("^MEDIUM POLISHED", p_type),
       p_size %in% c(49, 14, 23, 45, 19, 3, 36, 9)
     )
 
@@ -232,7 +232,7 @@ tpch_20 <- function() {
     select(s_suppkey, s_name, s_address)
 
   part_forest <- part |>
-    filter(prefix(p_name, "forest"))
+    filter(grepl("^forest", p_name))
 
   partsupp_forest_ca <- partsupp |>
     semi_join(na_matches = TPCH_NA_MATCHES, supplier_ca, c("ps_suppkey" = "s_suppkey")) |>

--- a/tools/36-tpch-bench-compare.R
+++ b/tools/36-tpch-bench-compare.R
@@ -1,11 +1,12 @@
 library(tidyverse)
 
-duckdb <- read_csv("res-duckdb.csv")
+duckdb <- read_csv("res-duckplyr.csv")
 dplyr <- read_csv("res-dplyr.csv")
 
 all <- bind_rows(dplyr, duckdb)
 
-all |>
-  filter(...1 != 21) |>
-  ggplot(aes(x = ...1, y = time, fill = pkg)) +
+graph <- all |>
+  ggplot(aes(x = query, y = time, fill = pkg)) +
   geom_col(position = "dodge")
+
+ggsave('tpch-results.pdf', plot = last_plot(), scale = 1, width = 15, height = 5, dpi=300)


### PR DESCRIPTION
In order to run the queries on both dplyr and duckdb with no errors or other changes required, we need to revert the prefix and suffix optimizations that were made. 

With the addition of https://github.com/duckdb/duckdb/pull/7181 data frames are scanned in parallel, so these optimizations aren't as necessary as before.

https://github.com/duckdb/duckdb/pull/7264 will also be merged after the release sometime. 