### PR TITLE
fix: `head(-1)` forwards to the default implementation

### DIFF
--- a/R/head.R
+++ b/R/head.R
@@ -2,12 +2,16 @@
 head.duckplyr_df <- function(x, n = 6L, ...) {
   stopifnot(is_integerish(n))
 
-  if (n < 0) {
-    return(NextMethod())
-  }
+  rel_try(call = list(name = "head", x = x, args = list(n = n)),
+    "Can't process negative n" = (n < 0),
+    {
+      rel <- duckdb_rel_from_df(x)
+      out_rel <- rel_limit(rel, n)
+      out <- rel_to_df(out_rel)
+      out <- dplyr_reconstruct(out, x)
+      return(out)
+    }
+  )
 
-  rel <- duckdb_rel_from_df(x)
-  out_rel <- rel_limit(rel, n)
-  out <- rel_to_df(out_rel)
-  dplyr_reconstruct(out, x)
+  NextMethod()
 }

--- a/R/head.R
+++ b/R/head.R
@@ -2,6 +2,10 @@
 head.duckplyr_df <- function(x, n = 6L, ...) {
   stopifnot(is_integerish(n))
 
+  if (n < 0) {
+    return(NextMethod())
+  }
+
   rel <- duckdb_rel_from_df(x)
   out_rel <- rel_limit(rel, n)
   out <- rel_to_df(out_rel)

--- a/tests/testthat/test-head.R
+++ b/tests/testthat/test-head.R
@@ -1,0 +1,32 @@
+test_that("head(2)", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  out <-
+    data.frame(a = 1:5) %>%
+    duckplyr::as_duckplyr_df() %>%
+    head(2)
+
+  expect_identical(out$a, 1:2)
+})
+
+test_that("head(-2)", {
+  withr::local_envvar(DUCKPLYR_FORCE = FALSE)
+
+  out <-
+    data.frame(a = 1:5) %>%
+    duckplyr::as_duckplyr_df() %>%
+    head(-2)
+
+  expect_identical(out$a, 1:3)
+})
+
+test_that("head(0)", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  out <-
+    data.frame(a = 1:5) %>%
+    duckplyr::as_duckplyr_df() %>%
+    head(0)
+
+  expect_identical(out$a, integer(0))
+})


### PR DESCRIPTION
Closes #131.