### PR TITLE
fix: Stricter type checks in the set operations `intersect()`, `setdiff()`, `symdiff()`, `union()`, and `union_all()`

### DIFF
--- a/R/intersect.R
+++ b/R/intersect.R
@@ -3,6 +3,7 @@
 intersect.duckplyr_df <- function(x, y, ...) {
   # Our implementation
   check_dots_empty()
+  check_compatible(x, y)
 
   x_names <- names(x)
   y_names <- names(y)

--- a/R/setdiff.R
+++ b/R/setdiff.R
@@ -3,6 +3,7 @@
 setdiff.duckplyr_df <- function(x, y, ...) {
   # Our implementation
   check_dots_empty()
+  check_compatible(x, y)
 
   x_names <- names(x)
   y_names <- names(y)

--- a/R/symdiff.R
+++ b/R/symdiff.R
@@ -3,6 +3,7 @@
 symdiff.duckplyr_df <- function(x, y, ...) {
   # Our implementation
   check_dots_empty()
+  check_compatible(x, y)
 
   x_names <- names(x)
   y_names <- names(y)

--- a/R/union_all.R
+++ b/R/union_all.R
@@ -3,6 +3,7 @@
 union_all.duckplyr_df <- function(x, y, ...) {
   # Our implementation
   check_dots_empty()
+  check_compatible(x, y)
 
   x_names <- names(x)
   y_names <- names(y)

--- a/patch/intersect.patch
+++ b/patch/intersect.patch
@@ -1,14 +1,15 @@
 diff --git b/R/intersect.R a/R/intersect.R
-index e080cd61..1338f61e 100644
+index e080cd61..925a5273 100644
 --- b/R/intersect.R
 +++ a/R/intersect.R
-@@ -2,9 +2,36 @@
+@@ -2,9 +2,37 @@
  #' @export
  intersect.duckplyr_df <- function(x, y, ...) {
    # Our implementation
 -  rel_try(
 -    "No relational implementation for intersect()" = TRUE,
 +  check_dots_empty()
++  check_compatible(x, y)
 +
 +  x_names <- names(x)
 +  y_names <- names(y)

--- a/patch/setdiff.patch
+++ b/patch/setdiff.patch
@@ -1,14 +1,15 @@
 diff --git b/R/setdiff.R a/R/setdiff.R
-index 314dcd7a..e14de004 100644
+index 314dcd7a..b5d303e7 100644
 --- b/R/setdiff.R
 +++ a/R/setdiff.R
-@@ -2,9 +2,36 @@
+@@ -2,9 +2,37 @@
  #' @export
  setdiff.duckplyr_df <- function(x, y, ...) {
    # Our implementation
 -  rel_try(
 -    "No relational implementation for setdiff()" = TRUE,
 +  check_dots_empty()
++  check_compatible(x, y)
 +
 +  x_names <- names(x)
 +  y_names <- names(y)

--- a/patch/symdiff.patch
+++ b/patch/symdiff.patch
@@ -1,14 +1,15 @@
 diff --git b/R/symdiff.R a/R/symdiff.R
-index dbd08df2..fc3ba0bf 100644
+index dbd08df2..c48b7fd2 100644
 --- b/R/symdiff.R
 +++ a/R/symdiff.R
-@@ -2,9 +2,38 @@
+@@ -2,9 +2,39 @@
  #' @export
  symdiff.duckplyr_df <- function(x, y, ...) {
    # Our implementation
 -  rel_try(
 -    "No relational implementation for symdiff()" = TRUE,
 +  check_dots_empty()
++  check_compatible(x, y)
 +
 +  x_names <- names(x)
 +  y_names <- names(y)

--- a/patch/union_all.patch
+++ b/patch/union_all.patch
@@ -1,14 +1,15 @@
 diff --git b/R/union_all.R a/R/union_all.R
-index ed860f18..d388804c 100644
+index ed860f18..168beb8a 100644
 --- b/R/union_all.R
 +++ a/R/union_all.R
-@@ -2,9 +2,38 @@
+@@ -2,9 +2,39 @@
  #' @export
  union_all.duckplyr_df <- function(x, y, ...) {
    # Our implementation
 -  rel_try(
 -    "No relational implementation for union_all()" = TRUE,
 +  check_dots_empty()
++  check_compatible(x, y)
 +
 +  x_names <- names(x)
 +  y_names <- names(y)


### PR DESCRIPTION
For #168.