### PR TITLE
feat: Support descending sort for character and other non-numeric data

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -85,7 +85,7 @@ handle_desc <- function(dots) {
     if (expr[[1]] != "desc")  next
 
     # Check that desc is called with a single argument
-    # (we cannot return more than one argument due to expectations of rel_translate_dots)
+    # (dplyr::desc() accepts only one argument)
     if (length(expr) > 2) cli::cli_abort("desc() must be called with exactly one argument.")
 
     ascending[i] <- FALSE

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -79,17 +79,17 @@ handle_desc <- function(dots) {
   ascending <- rep(TRUE, length(dots))
 
   for (i in seq_along(dots)) {
-    expr <- get_expr(dots[[i]])
+    expr <- quo_get_expr(dots[[i]])
 
     if (!is.call(expr))       next
     if (expr[[1]] != "desc")  next
 
     # Check that desc is called with a single argument
     # (dplyr::desc() accepts only one argument)
-    if (length(expr) > 2) cli::cli_abort("desc() must be called with exactly one argument.")
+    if (length(expr) > 2) cli::cli_abort("`desc()` must be called with exactly one argument.")
 
     ascending[i] <- FALSE
-    dots[[i]]    <- new_quosure(expr[[2]])
+    dots[[i]]    <- new_quosure(expr[[2]], env = quo_get_env(dots[[i]]))
   }
 
   list(dots = dots, ascending = ascending)

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -26,7 +26,7 @@ arrange.duckplyr_df <- function(.data, ..., .by_group = FALSE, .locale = NULL) {
       if (oo_force()) {
         rel <- oo_prep(rel, force = TRUE)
         exprs <- c(exprs, list(relexpr_reference("___row_number")))
-        ascending <- c(ascending,TRUE)
+        ascending <- c(ascending, TRUE)
       }
 
       rel <- rel_order(rel, exprs, ascending)
@@ -92,5 +92,5 @@ handle_desc <- function(dots) {
     dots[[i]]    <- new_quosure(expr[[2]])
   }
 
-  list(dots = dots,ascending = ascending)
+  list(dots = dots, ascending = ascending)
 }

--- a/R/relational-duckdb.R
+++ b/R/relational-duckdb.R
@@ -52,7 +52,6 @@ duckplyr_macros <- c(
   #
   # FIXME: Need a better way?
   "suppressWarnings" = "(x) AS (x)",
-  "desc" = "(x) AS (x)",
   #
   NULL
 )
@@ -238,13 +237,11 @@ rel_aggregate.duckdb_relation <- function(rel, groups, aggregates, ...) {
 }
 
 #' @export
-rel_order.duckdb_relation <- function(rel, orders, ...) {
-
-  ascending <- sapply(orders, function(order) order$name != "desc" )
+rel_order.duckdb_relation <- function(rel, orders, ascending, ...) {
 
   duckdb_orders <- to_duckdb_exprs(orders)
 
-  out <- duckdb$rel_order(rel, duckdb_orders, ascending)
+  out <- duckdb$rel_order(rel, duckdb_orders, ascending)  
 
   meta_rel_register(out, expr(duckdb$rel_order(
     !!meta_rel_get(rel)$name,

--- a/R/relational-duckdb.R
+++ b/R/relational-duckdb.R
@@ -237,7 +237,7 @@ rel_aggregate.duckdb_relation <- function(rel, groups, aggregates, ...) {
 }
 
 #' @export
-rel_order.duckdb_relation <- function(rel, orders, ascending, ...) {
+rel_order.duckdb_relation <- function(rel, orders, ascending = NULL, ...) {
 
   duckdb_orders <- to_duckdb_exprs(orders)
 

--- a/R/relational-duckdb.R
+++ b/R/relational-duckdb.R
@@ -43,7 +43,6 @@ duckplyr_macros <- c(
   "&" = "(x, y) AS (x AND y)",
   "!" = "(x) AS (NOT x)",
   "any" = "(x) AS (bool_or(x))",
-  "desc" = "(x) AS (-x)",
   "n_distinct" = "(x) AS (COUNT(DISTINCT x))",
   #
   "wday" = "(x) AS CAST(weekday(CAST (x AS DATE)) + 1 AS int32)",
@@ -53,6 +52,7 @@ duckplyr_macros <- c(
   #
   # FIXME: Need a better way?
   "suppressWarnings" = "(x) AS (x)",
+  "desc" = "(x) AS (x)",
   #
   NULL
 )
@@ -239,9 +239,12 @@ rel_aggregate.duckdb_relation <- function(rel, groups, aggregates, ...) {
 
 #' @export
 rel_order.duckdb_relation <- function(rel, orders, ...) {
+
+  ascending <- sapply(orders, function(order) order$name != "desc" )
+
   duckdb_orders <- to_duckdb_exprs(orders)
 
-  out <- duckdb$rel_order(rel, duckdb_orders)
+  out <- duckdb$rel_order(rel, duckdb_orders, ascending)
 
   meta_rel_register(out, expr(duckdb$rel_order(
     !!meta_rel_get(rel)$name,

--- a/R/relational-rel.R
+++ b/R/relational-rel.R
@@ -141,7 +141,7 @@ rel_aggregate <- function(rel, groups, aggregates, ...) {
 #' to be used by [dplyr::arrange()].
 #'
 #' @param orders A list of expressions to order by.
-#' @param ascending A logical vector describing the sort order
+#' @param ascending A logical vector describing the sort order.
 #' @rdname new_relational
 #' @export
 #' @examples

--- a/R/relational-rel.R
+++ b/R/relational-rel.R
@@ -141,6 +141,7 @@ rel_aggregate <- function(rel, groups, aggregates, ...) {
 #' to be used by [dplyr::arrange()].
 #'
 #' @param orders A list of expressions to order by.
+#' @param ascending A logical vector describing the sort order
 #' @rdname new_relational
 #' @export
 #' @examples
@@ -157,7 +158,7 @@ rel_aggregate <- function(rel, groups, aggregates, ...) {
 #'   mtcars_rel,
 #'   list(relexpr_reference("mpg"))
 #' )
-rel_order <- function(rel, orders, ...) {
+rel_order <- function(rel, orders, ascending, ...) {
   rel_stats_env$rel_order <- (rel_stats_env$rel_order %||% 0L) + 1L
   UseMethod("rel_order")
 }

--- a/man/new_relational.Rd
+++ b/man/new_relational.Rd
@@ -30,7 +30,7 @@ rel_project(rel, exprs, ...)
 
 rel_aggregate(rel, groups, aggregates, ...)
 
-rel_order(rel, orders, ...)
+rel_order(rel, orders, ascending, ...)
 
 rel_join(
   left,
@@ -75,6 +75,8 @@ rel_names(rel, ...)
 \item{aggregates}{A list of expressions with aggregates to compute.}
 
 \item{orders}{A list of expressions to order by.}
+
+\item{ascending}{A logical vector describing the sort order.}
 
 \item{conds}{A list of expressions to use for the join.}
 


### PR DESCRIPTION
Closes #92.

Creating a `desc` macro feels a bit like a work-around as it is created for the sole purpose of not raising a function-not-found -error. Couldn't think of an easy alternative. What do you think @krlmlr ?