### PR TITLE
find calls for `box` package use

### DIFF
--- a/R/translate.R
+++ b/R/translate.R
@@ -3,8 +3,8 @@
 rel_find_call <- function(fun, env) {
   name <- as.character(fun)
 
-  if (name[[1]] == "::") {
-    # Fully qualified name, no check needed
+  if (length(name) == 3 && name[[1]] %in% c("::", "$")) {
+    # Fully qualified name (base: "::", box: "$"), no check needed
     return(c(name[[2]], name[[3]]))
   } else if (length(name) != 1) {
     cli::cli_abort("Can't translate function {.code {expr_deparse(fun)}}.")


### PR DESCRIPTION
I noticed that the function translation doesn't work (yet) in combination with the `box` package:

``` r
box::use(
  duckplyr
)
#> The duckplyr package is configured to fall back to dplyr when it encounters an
#> incompatibility. Fallback events can be collected and uploaded for analysis to
#> guide future development. By default, no data will be collected or uploaded.
#> → Run `duckplyr::fallback_sitrep()` to review the current settings.

options(duckdb.materialize_message = FALSE)

# Triggers fallback
mtcars_rows <- 
  mtcars |> 
  duckplyr$as_duckplyr_tibble() |> 
  duckplyr$mutate(row_num = duckplyr$row_number())
#> The duckplyr package is configured to fall back to dplyr when it encounters an
#> incompatibility. Fallback events can be collected and uploaded for analysis to
#> guide future development. By default, no data will be collected or uploaded.
#> ℹ A fallback situation just occurred. The following information would have been
#>   recorded:
#>   {"version":"0.4.1","message":"Can't translate function
#>   `duckplyr$row_number`.","name":"mutate","x":{"...1":"numeric","...2":"numeric","...3":"numeric","...4":"numeric","...5":"numeric","...6":"numeric","...7":"numeric","...8":"numeric","...9":"numeric","...10":"numeric","...11":"numeric"},"args":{"dots":{"...12":"...13$...14()"},".by":"NULL",".keep":["all","used","unused","none"]}}
#> → Run `duckplyr::fallback_sitrep()` to review the current settings.
#> → Run `Sys.setenv(DUCKPLYR_FALLBACK_COLLECT = 1)` to enable fallback logging,
#>   and `Sys.setenv(DUCKPLYR_FALLBACK_VERBOSE = TRUE)` in addition to enable
#>   printing of fallback situations to the console.
#> → Run `duckplyr::fallback_review()` to review the available reports, and
#>   `duckplyr::fallback_upload()` to upload them.
#> ℹ See `?duckplyr::fallback()` for details.
#> ℹ This message will be displayed once every eight hours.
#> Error processing with relational.
#> Caused by error in `rel_find_call()`:
#> ! Can't translate function `duckplyr$row_number`.

# Works as intended
mtcars_rows <- 
  mtcars |> 
  duckplyr$as_duckplyr_tibble() |> 
  duckplyr$mutate(row_num = duckplyr::row_number())
```

<sup>Created on 2024-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessionInfo()
#> R version 4.2.3 (2023-03-15 ucrt)
#> Platform: x86_64-w64-mingw32/x64 (64-bit)
#> Running under: Windows 10 x64 (build 22631)
#> 
#> Matrix products: default
#> 
#> locale:
#> [1] LC_COLLATE=German_Germany.utf8  LC_CTYPE=German_Germany.utf8   
#> [3] LC_MONETARY=German_Germany.utf8 LC_NUMERIC=C                   
#> [5] LC_TIME=German_Germany.utf8    
#> 
#> attached base packages:
#> [1] stats     graphics  grDevices utils     datasets  methods   base     
#> 
#> loaded via a namespace (and not attached):
#>  [1] rstudioapi_0.16.0 knitr_1.48        magrittr_2.0.3    tidyselect_1.2.1 
#>  [5] R6_2.5.1          rlang_1.1.4       fastmap_1.2.0     fansi_1.0.6      
#>  [9] dplyr_1.1.4       tools_4.2.3       xfun_0.46         utf8_1.2.4       
#> [13] DBI_1.2.3         cli_3.6.3         withr_3.0.0       htmltools_0.5.8.1
#> [17] yaml_2.3.10       digest_0.6.36     tibble_3.2.1      lifecycle_1.0.4  
#> [21] box_1.2.0         duckdb_1.0.0      vctrs_0.6.5       fs_1.6.4         
#> [25] glue_1.7.0        evaluate_0.24.0   rmarkdown_2.27    reprex_2.1.1     
#> [29] compiler_4.2.3    duckplyr_0.4.1    pillar_1.9.0      generics_0.1.3   
#> [33] collections_0.3.7 jsonlite_1.8.8    pkgconfig_2.0.3
```

</details>

I suggest adding the `$` operator to the "fully qualified" package + name case. I also added an extra check that `length(name) == 3` to avoid some (unexpected) nested special cases like `list$packagename$functionname()`.