### PR TITLE
feat: Implement `n_distinct()` as macro with support for `na.rm = TRUE`

### DIFF
--- a/R/relational-duckdb.R
+++ b/R/relational-duckdb.R
@@ -50,7 +50,6 @@ duckplyr_macros <- c(
   "|" = "(x, y) AS (x OR y)",
   "&" = "(x, y) AS (x AND y)",
   "!" = "(x) AS (NOT x)",
-  "n_distinct" = "(x) AS (COUNT(DISTINCT x))",
   #
   "wday" = "(x) AS CAST(weekday(CAST (x AS DATE)) + 1 AS int32)",
   #
@@ -68,6 +67,10 @@ duckplyr_macros <- c(
   "___mean_na" = "(x) AS (CASE WHEN SUM(CASE WHEN x IS NULL THEN 1 ELSE 0 END) > 0 THEN NULL ELSE AVG(x) END)",
   "___sd_na" = "(x) AS (CASE WHEN SUM(CASE WHEN x IS NULL THEN 1 ELSE 0 END) > 0 THEN NULL ELSE STDDEV(x) END)",
   "___median_na" = "(x) AS (CASE WHEN SUM(CASE WHEN x IS NULL THEN 1 ELSE 0 END) > 0 THEN NULL ELSE percentile_cont(0.5) WITHIN GROUP (ORDER BY x) END)",
+  #
+  # In n_distinct() many NAs count as 1 if not filtered out with na.rm = TRUE
+  "___n_distinct_na" = "(x) AS (CASE WHEN SUM(CASE WHEN x IS NULL THEN 1 ELSE 0 END) > 0 THEN (COUNT(DISTINCT x)+1) ELSE COUNT(DISTINCT x) END)",
+  "___n_distinct" = "(x) AS (COUNT(DISTINCT x))",
   #
   NULL
 )

--- a/R/translate.R
+++ b/R/translate.R
@@ -179,7 +179,7 @@ rel_translate_lang <- function(
   }
 
 
-  if (!(name %in% c("wday", "strftime", "lag", "lead", "sum", "min", "max", "any", "all", "mean", "median", "sd"))) {
+  if (!(name %in% c("wday", "strftime", "lag", "lead", "sum", "min", "max", "any", "all", "mean", "median", "sd", "n_distinct"))) {
     if (!is.null(names(expr)) && any(names(expr) != "")) {
       # Fix grepl() and sum()/min()/max() logic below when allowing matching by argument name
       cli::cli_abort("Can't translate named argument {.code {name}({names(expr)[names(expr) != ''][[1]]} = )}.", call = call)
@@ -296,6 +296,7 @@ rel_translate_lang <- function(
 
     # Aggregates
     "sum", "min", "max", "any", "all", "mean", "sd", "median",
+    "n_distinct",
     #
     NULL
   )
@@ -334,7 +335,7 @@ rel_translate_lang <- function(
 
   # Other primitives: prod, range
   # Other aggregates: var(), cum*(), quantile()
-  if (name %in% c("sum", "min", "max", "any", "all", "mean", "sd", "median")) {
+  if (name %in% c("sum", "min", "max", "any", "all", "mean", "sd", "median", "n_distinct")) {
     is_primitive <- (name %in% c("sum", "min", "max", "any", "all"))
 
     if (is_primitive) {
@@ -365,18 +366,26 @@ rel_translate_lang <- function(
     }
 
     if (window) {
-      if (identical(na_rm, FALSE)) {
-        cli::cli_abort(call = call, c(
-          "{.code {name}(na.rm = FALSE)} not supported in window functions",
-          i = "Use {.code {name}(na.rm = TRUE)} after checking for missing values"
-        ))
-      } else if (!identical(na_rm, TRUE)) {
-        cli::cli_abort("Invalid value for {.arg na.rm} in call to {.fun {name}}", call = call)
+      if (name == "n_distinct") {
+        cli::cli_abort("{.code {name}()} not supported in window functions", call = call)
+      } else {
+        if (identical(na_rm, FALSE)) {
+          cli::cli_abort(call = call, c(
+            "{.code {name}(na.rm = FALSE)} not supported in window functions",
+            i = "Use {.code {name}(na.rm = TRUE)} after checking for missing values"
+          ))
+        } else if (!identical(na_rm, TRUE)) {
+          cli::cli_abort("Invalid value for {.arg na.rm} in call to {.fun {name}}", call = call)
+        }
       }
     } else {
       if (identical(na_rm, FALSE)) {
         aliased_name <- paste0("___", name, "_na") # ___sum_na, ___min_na, ___max_na
-      } else if (!identical(na_rm, TRUE)) {
+      } else if (identical(na_rm, TRUE)) {
+        if (name == "n_distinct") {
+          aliased_name <- paste0("___", name)         
+        }
+      } else {
         cli::cli_abort("Invalid value for {.arg na.rm} in call to {.fun {name}}", call = call)
       }
     }

--- a/tests/testthat/_snaps/n_distinct.md
+++ b/tests/testthat/_snaps/n_distinct.md
@@ -1,0 +1,24 @@
+# duckdb n_distinct() error with more than one argument
+
+    Code
+      df %>% summarise(dummy = n_distinct(a, b))
+    Condition
+      Error in `summarise()`:
+      ! `n_distinct()` needs exactly one argument besides the optional `na.rm`
+
+# duckdb n_distinct() error with na.rm not being TRUE/FALSE
+
+    Code
+      df %>% summarise(dummy = n_distinct(a, na.rm = "b"))
+    Condition
+      Error in `summarise()`:
+      ! Invalid value for `na.rm` in call to `n_distinct()`
+
+# duckdb n_distinct() error with mutate
+
+    Code
+      df %>% mutate(dummy = n_distinct(a))
+    Condition
+      Error in `mutate()`:
+      ! `n_distinct()` not supported in window functions
+

--- a/tests/testthat/test-n_distinct.R
+++ b/tests/testthat/test-n_distinct.R
@@ -1,0 +1,149 @@
+test_that("duckdb n_distinct() basic", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  df <- duckdb_tibble(
+    a = c(1, 1, 2, 2, 2), 
+    b = c(3, 3, NA, 3, 3)
+  )
+
+  out <- df %>%
+    summarise( n_distinct_a = n_distinct(a),
+               n_distinct_a_na_rm = n_distinct(a, na.rm = TRUE),
+               n_distinct_b = n_distinct(b, na.rm = FALSE),
+               n_distinct_b_na_rm = n_distinct(b, na.rm = TRUE)
+    )
+
+  expect_equal(out$n_distinct_a, 2)
+  expect_equal(out$n_distinct_a_na_rm, 2)
+  expect_equal(out$n_distinct_b, 2)
+  expect_equal(out$n_distinct_b_na_rm, 1)
+})
+
+
+test_that("duckdb n_distinct() counts empty inputs", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  df <- duckdb_tibble(
+    a = integer(), 
+    b = double(), 
+    c = logical(), 
+    d = character()
+  )
+
+  out <- df %>%
+    summarise( n_distinct_a = n_distinct(a),
+               n_distinct_b = n_distinct(b),
+               n_distinct_c = n_distinct(c),
+               n_distinct_d = n_distinct(d),
+    )
+
+  expect_equal(out$n_distinct_a, 0)
+  expect_equal(out$n_distinct_b, 0)
+  expect_equal(out$n_distinct_c, 0)
+  expect_equal(out$n_distinct_d, 0)
+})
+
+
+test_that("duckdb n_distinct() counts unique values in simple vectors", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  df <- duckdb_tibble(
+    a = c(TRUE, FALSE, NA), 
+    b = c(1, 2, NA), 
+    c = c(1L, 2L, NA), 
+    d = c("x", "y", NA)
+  )
+
+  out <- df %>%
+    summarise( n_distinct_a = n_distinct(a),
+               n_distinct_b = n_distinct(b),
+               n_distinct_c = n_distinct(c),
+               n_distinct_d = n_distinct(d),
+    )
+
+  expect_equal(out$n_distinct_a, 3)
+  expect_equal(out$n_distinct_b, 3)
+  expect_equal(out$n_distinct_c, 3)
+  expect_equal(out$n_distinct_d, 3)
+})
+
+
+test_that("duckdb n_distinct() can drop missing values", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  df <- duckdb_tibble(
+    a = c(NA), 
+    b = c(NA, 0), 
+  )
+
+  out <- df %>%
+    summarise( n_distinct_a = n_distinct(a, na.rm = TRUE),
+               n_distinct_b = n_distinct(b, na.rm = TRUE),
+    )
+
+  expect_equal(out$n_distinct_a, 0)
+  expect_equal(out$n_distinct_b, 1)
+})
+
+
+test_that("duckdb n_distinct() counts NA correctly", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  df <- duckdb_tibble(
+    a = c(1, NA, 1, NA, 2, NA, 2), 
+    b = c(3, 3, NA, 3, NA, 4, 5)
+  )
+
+  out <- df %>%
+    summarise( n_distinct_a = n_distinct(a),
+               n_distinct_a_na_rm = n_distinct(a, na.rm = TRUE),
+               n_distinct_b = n_distinct(b, na.rm = FALSE),
+               n_distinct_b_na_rm = n_distinct(b, na.rm = TRUE)
+    )
+
+  expect_equal(out$n_distinct_a, 3)
+  expect_equal(out$n_distinct_a_na_rm, 2)
+  expect_equal(out$n_distinct_b, 4)
+  expect_equal(out$n_distinct_b_na_rm, 3)
+})
+
+
+test_that("duckdb n_distinct() error with more than one argument", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  df <- duckdb_tibble(
+    a = c(1, 1, 2, 2, 2), 
+    b = c(3, 3, NA, 3, 3)
+  )
+  
+  expect_snapshot( error = TRUE, {
+    df %>% summarise( dummy = n_distinct(a, b) )
+  })
+})
+
+
+test_that("duckdb n_distinct() error with na.rm not being TRUE/FALSE", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  df <- duckdb_tibble(
+    a = c(1, 2), 
+  )
+  
+  expect_snapshot( error = TRUE, {
+    df %>% summarise( dummy = n_distinct(a, na.rm = "b") )
+  })
+})
+
+
+test_that("duckdb n_distinct() error with mutate", {
+  withr::local_envvar(DUCKPLYR_FORCE = TRUE)
+
+  df <- duckdb_tibble(
+    a = c(1, 1, 2, 2, 2), 
+    b = c(3, 3, NA, 3, 3)
+  )
+  
+  expect_snapshot( error = TRUE, {
+    df %>% mutate( dummy = n_distinct(a) )
+  })
+})

--- a/vignettes/limits.Rmd
+++ b/vignettes/limits.Rmd
@@ -388,24 +388,9 @@ tibble(a = c(TRUE, FALSE)) |>
   summarize(min(a), max(a))
 ```
 
-### `n_distinct()` and missing values
+### `n_distinct()` and multiple arguments
 
-Unlike most other aggregation functions, `n_distinct()` ignores missing values and does not support the `na.rm` argument.
-This is tracked in <https://github.com/tidyverse/duckplyr/issues/572>.
-
-```{r error = TRUE}
-duckplyr::duckdb_tibble(a = c(1, 2, NA, 1)) |>
-  summarize(n_distinct(a))
-
-duckplyr::duckdb_tibble(a = c(1, 2, NA, 1), .prudence = "stingy") |>
-  summarize(n_distinct(a, na.rm = TRUE))
-
-tibble(a = c(1, 2, NA, 1)) |>
-  summarize(n_distinct(a))
-
-tibble(a = c(1, 2, NA, 1)) |>
-  summarize(n_distinct(a, na.rm = TRUE))
-```
+This function needs exactly one argument besides the optional `na.rm`. Multiple arguments is not supported.
 
 ### `is.na()` and `NaN` values
 


### PR DESCRIPTION
I wish it was possible to support multiple arguments to `n_distinct()` but I haven't been able to find a solution using macros. If you have a suggestion, please let me know. 

Fixes #572