### PR TITLE
fledge: CRAN release v1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: duckplyr
 Title: A 'DuckDB'-Backed Version of 'dplyr'
-Version: 1.0.99.9904
+Version: 1.1.0
 Authors@R: c(
     person("Hannes", "Mühleisen", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,34 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckplyr 1.0.99.9904 (2025-05-08)
-
-## Chore
-
-- Move compat checks back to duckplyr.
-
-
-# duckplyr 1.0.99.9903 (2025-05-08)
-
-## Chore
-
-- Move compatibility checks to duckdb (#699).
-
-
-# duckplyr 1.0.99.9902 (2025-05-04)
-
-## Continuous integration
-
-- Enhance permissions for workflow (#717).
-
-
-# duckplyr 1.0.99.9901 (2025-05-02)
-
-## Chore
-
-- Bump duckdb dependency.
-
-
-# duckplyr 1.0.99.9900 (2025-04-29)
+# duckplyr 1.1.0 (2025-05-08)
 
 ## fledge
 
@@ -66,6 +38,12 @@
 
 ## Chore
 
+- Move compat checks back to duckplyr.
+
+- Move compatibility checks to duckdb (#699).
+
+- Bump duckdb dependency.
+
 - Remove access of unknown variable.
 
 - Sync.
@@ -91,6 +69,8 @@
 - Check loadability of extensino in test (#636).
 
 ## Continuous integration
+
+- Enhance permissions for workflow (#717).
 
 - Permissions, better tests for missing suggests, lints (#710).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,26 @@
 
 # duckplyr 1.1.0 (2025-05-08)
 
-## fledge
+This release improves compatibility with dbplyr and DuckDB.
+See `vignette("duckdb")` for details.
 
-- CRAN release v1.0.1 (#624).
+## Features
+
+- Pass functions prefixed with `dd$` directly to DuckDB, e.g., `dd$ROW()` will be translated as DuckDB's `ROW()` function (#658).
+
+- New `as_tbl()` to convert to a dbplyr tbl object (#634, #685).
+
+- Register Ark methods for Positron's Variables Pane (@DavisVaughan, #661, #678).
+
+- Translate `n_distinct()` as macro with support for `na.rm = TRUE` (@joakimlinde, #572, #655).
+
+- Translate `coalesce()`.
+
+- `compute()` does not have a fallback, failures are reported to the client (#637).
+
+- Implement `slice_head()` (#640).
 
 ## Bug fixes
-
-- Syntax in code generation.
 
 - Set functions like `union()` no longer trigger materialization (#654, #692).
 
@@ -16,49 +29,11 @@
 
 - Correct formatting for controlled fallbacks with `Sys.setenv(DUCKPLYR_FALLBACK_INFO = TRUE)`.
 
-## Features
-
-- Remove experimental flag (#682, #695).
-
-- Register `has_children` and `has_viewer` methods for Positron (#678).
-
-- Passthrough of functions prefixed with `dd$`, e.g., `dd$ROW()` will be translated as DuckDB's `ROW()` function (#658).
-
-- New `as_tbl()` to convert to a dbplyr tbl object (#634, #685).
-
-- Register Ark methods for Positron's Variables Pane (@DavisVaughan, #661).
-
-- Implement `n_distinct()` as macro with support for `na.rm = TRUE` (@joakimlinde, #572, #655).
-
-- Translate `dplyr::coalesce()`.
-
-- `compute()` does not have a fallback, failures are reported to the client (#637).
-
-- Implement `slice_head()` (#640).
-
 ## Chore
 
-- Move compat checks back to duckplyr.
-
-- Move compatibility checks to duckdb (#699).
-
-- Bump duckdb dependency.
-
-- Remove access of unknown variable.
-
-- Sync.
-
-- Remove superfluous check.
-
-- Fix lints.
-
-- Remove space at EOL.
-
-- Bump required version of pillar.
+- Bump duckdb and pillar dependencies.
 
 - Use roxyglobals from CRAN rather than GitHub (@andreranza, #659).
-
-- Space at EOL.
 
 - Bring tools and patch up to date (@joakimlinde, #647).
 
@@ -66,29 +41,11 @@
 
 - Fix sync scripts and add reproducible code (#639).
 
-- Check loadability of extensino in test (#636).
-
-## Continuous integration
-
-- Enhance permissions for workflow (#717).
-
-- Permissions, better tests for missing suggests, lints (#710).
-
-- Only fail covr builds if token is given (#707).
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#706).
-
-- Correct installation of xml2 (#703).
-
-- Add xml2 for covr, print testthat results (#701).
-
-- Sync (#700).
+- Check loadability of extensions in test (#636).
 
 ## Documentation
 
 - Document `slice_head()` as supported.
-
-- Move package.
 
 - Add Posit's ROR ID (#592).
 
@@ -100,13 +57,9 @@
 
 - Typos + clarification edits to "large" vignette (@mine-cetinkaya-rundel, #665).
 
-- Recommend `pak::pak()`.
-
 ## Testing
 
 - Skip tests using `grep()` or `sub()` on CRAN.
-
-- Snapshot updates for rcc-smoke (null) (#675).
 
 
 # duckplyr 1.0.1 (2025-02-21)

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ See `vignette("duckdb")` for details.
 
 - New `as_tbl()` to convert to a dbplyr tbl object (#634, #685).
 
-- Register Ark methods for Positron's Variables Pane (@DavisVaughan, #661, #678).
+- Register Ark methods for Positron's "Variables" pane (@DavisVaughan, #661, #678). DuckDB tibbles are no longer displayed as data frames in the "Variables" pane due to a limitation in Positron. Use `collect()` to convert them to data frames if you rely on the viewer functionality.
 
 - Translate `n_distinct()` as macro with support for `na.rm = TRUE` (@joakimlinde, #572, #655).
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckplyr 1.0.99.9900
+duckplyr 1.1.0
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-05-08, problems found: https://cran.r-project.org/web/checks/check_results_duckplyr.html
- [ ] ERROR: r-devel-linux-x86_64-fedora-clang
     Running ‘testthat.R’ [248s/347s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > # This file is part of the standard setup for testthat.
     > # It is recommended that you do not modify it.
     > #
     > # Where should you do additional test configuration?
     > # Learn more about the roles of various files in:
     > # * https://r-pkgs.org/tests.html
     > # * https://testthat.r-lib.org/reference/test_package.html#special-files
     > 
     > library(testthat)
     > library(duckplyr)
     Loading required package: dplyr
     
     Attaching package: 'dplyr'
     
     The following object is masked from 'package:testthat':
     
     matches
     
     The following objects are masked from 'package:stats':
     
     filter, lag
     
     The following objects are masked from 'package:base':
     
     intersect, setdiff, setequal, union
     
     The duckplyr package is configured to fall back to dplyr when it encounters an
     incompatibility. Fallback events can be collected and uploaded for analysis to
     guide future development. By default, data will be collected but no data will
     be uploaded.
     ℹ Automatic fallback uploading is not controlled and therefore disabled, see
     `?duckplyr::fallback()`.
     ✔ Number of reports ready for upload: 2.
     → Review with `duckplyr::fallback_review()`, upload with
     `duckplyr::fallback_upload()`.
     ℹ Configure automatic uploading with `duckplyr::fallback_config()`.
     ✔ Overwriting dplyr methods with duckplyr methods.
     ℹ Turn off with `duckplyr::methods_restore()`.
     > 
     > test_check("duckplyr")
     
     *** caught segfault ***
     address (nil), cause 'unknown'
     
     Traceback:
     1: rapi_execute(stmt, convert_opts)
     2: withCallingHandlers(expr, condition = function(cnd) {    {        .__handler_frame__. <- TRUE        .__setup_frame__. <- frame        if (inherits(cnd, "message")) {            except <- c("warning", "error")  

Check results at: https://cran.r-project.org/web/checks/check_results_duckplyr.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`