### PR TITLE
fledge: CRAN release v1.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: duckplyr
 Title: A 'DuckDB'-Backed Version of 'dplyr'
-Version: 1.1.0.9001
+Version: 1.1.1
 Authors@R: c(
     person("Hannes", "Mühleisen", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckplyr 1.1.0.9001 (2025-07-29)
+# duckplyr 1.1.1 (2025-07-29)
 
 ## Chore
 
@@ -14,8 +14,7 @@
 
 - Add strictness.
 
-
-# duckplyr 1.1.0.9000 (2025-05-09)
+## Uncategorized
 
 - Switching to development version.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckplyr 1.1.0
+duckplyr 1.1.1
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-07-29, problems found: https://cran.r-project.org/web/checks/check_results_duckplyr.html
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/donttest/duckplyr.out>

Check results at: https://cran.r-project.org/web/checks/check_results_duckplyr.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`