### PR TITLE
compat: `as_tbl()` attach finalizer to `lazy_query`, not `tbl`, for compatibility with dbplyr 2.6.0

### DIFF
--- a/R/as_tbl.R
+++ b/R/as_tbl.R
@@ -50,6 +50,6 @@ as_tbl <- function(.data) {
   duckdb$rel_to_view(rel, "", name, temporary = TRUE)
 
   out <- dplyr::tbl(con, name)
-  attr(out, "duckplyr_scope_guard") <- scope_guard
+  attr(out$lazy_query, "duckplyr_scope_guard") <- scope_guard
   out
 }


### PR DESCRIPTION
(Claude analysis follows, needed for dbplyr 2.6.0 release)

`as_tbl()` currently anchors the temp-view finalizer to the top-level tbl:

```r
out <- dplyr::tbl(con, name)
attr(out, "duckplyr_scope_guard") <- scope_guard
out
```

This relies on attributes surviving every dbplyr verb. Today they happen to — verbs mutate in place (`out$lazy_query <- ...`), which preserves attributes by R copy semantics — but it's not a contract, and it already fails in cases like joins (where the RHS tbl is consumed, dropping any `attr(y, ...)`) and any verb that rebuilds via `dplyr::make_tbl()`. The cascading effect is visible in dbplyr's 2.6.0 revdep run: osdc breaks with `Table as_tbl_duckplyr_XXX does not exist` because GC reclaims the guard before `collect()` runs.

The fix is one line — anchor to the `lazy_query` instead:

```r
out <- dplyr::tbl(con, name)
attr(out$lazy_query, "duckplyr_scope_guard") <- scope_guard
out
```

The lazy_query tree is the durable spine of a dbplyr tbl: every verb wraps the prior query as `$x` of the new one, and joins retain both sides as `x_lq` / `y_lq`. So the root node (and the attribute) stays GC-reachable for the lifetime of any derivative tbl, including across joins where both inputs came from `as_tbl()`. Verified empirically against current dbplyr `main`: the finalizer fires at the right moment after mutate / filter / head / collect chains.