### PR TITLE
fledge: CRAN pre-release v1.2.1.9900

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: duckplyr
 Title: A 'DuckDB'-Backed Version of 'dplyr'
-Version: 1.2.1.9012
+Version: 1.2.1.9900
 Authors@R: c(
     person("Hannes", "Mühleisen", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,28 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckplyr 1.2.1.9012 (2026-05-24)
+# duckplyr 1.2.1.9900 (2026-06-17)
+
+## compat
+
+- `as_tbl()` attach finalizer to `lazy_query`, not `tbl`, for compatibility with dbplyr 2.6.0 (#919).
+
+## fledge
+
+- CRAN release v1.2.1 (#898).
+
+## Features
+
+- Enable `across()` translation for primitive functions such as `sum()` (#906, #907).
+
+## Chore
+
+- Add ccache to `.gitignore` and `.Rbuildignore`.
+
+- Auto-update from GitHub Actions (#913).
+
+- Auto-update from GitHub Actions (#902).
+
+- Auto-update from GitHub Actions (#900).
 
 ## Continuous integration
 
@@ -8,49 +30,13 @@
 
 - Bump action version.
 
-
-# duckplyr 1.2.1.9011 (2026-05-16)
-
-- Ci: Unify fledge.yaml across cynkratemplate and fledge (#86).
-
-
-# duckplyr 1.2.1.9010 (2026-05-14)
-
-## compat
-
-- `as_tbl()` attach finalizer to `lazy_query`, not `tbl`, for compatibility with dbplyr 2.6.0 (#919).
-
-
-# duckplyr 1.2.1.9009 (2026-05-13)
-
-## Chore
-
-- Add ccache to `.gitignore` and `.Rbuildignore`.
-
-## Continuous integration
-
 - Create snapshot update PR against correct branch.
 
 - Clarify rationale for not deploying on schedule.
 
-
-# duckplyr 1.2.1.9008 (2026-05-10)
-
-## Continuous integration
-
 - Only run fledge on pushes to main.
 
-
-# duckplyr 1.2.1.9007 (2026-05-10)
-
-## Continuous integration
-
 - Tweak fledge workflow and ccache action.
-
-
-# duckplyr 1.2.1.9006 (2026-05-06)
-
-## Continuous integration
 
 - Cosmetics.
 
@@ -62,51 +48,15 @@
 
 - Harmonize.
 
-
-# duckplyr 1.2.1.9005 (2026-05-04)
-
-## Chore
-
-- Auto-update from GitHub Actions (#913).
-
-
-# duckplyr 1.2.1.9004 (2026-04-11)
+- Ignore failing test with duckdb 1.5.0.
 
 ## Documentation
 
 - Update Plausible analytics snippet (@jeroenjanssens, #910).
 
+## Uncategorized
 
-# duckplyr 1.2.1.9003 (2026-03-28)
-
-## Features
-
-- Enable `across()` translation for primitive functions such as `sum()` (#906, #907).
-
-## Continuous integration
-
-- Ignore failing test with duckdb 1.5.0.
-
-
-# duckplyr 1.2.1.9002 (2026-03-13)
-
-## Chore
-
-- Auto-update from GitHub Actions (#902).
-
-
-# duckplyr 1.2.1.9001 (2026-03-12)
-
-## Chore
-
-- Auto-update from GitHub Actions (#900).
-
-
-# duckplyr 1.2.1.9000 (2026-03-10)
-
-## fledge
-
-- CRAN release v1.2.1 (#898).
+- Ci: Unify fledge.yaml across cynkratemplate and fledge (#86).
 
 
 # duckplyr 1.2.1 (2026-03-09)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,61 +2,17 @@
 
 # duckplyr 1.2.1.9900 (2026-06-17)
 
-## compat
-
-- `as_tbl()` attach finalizer to `lazy_query`, not `tbl`, for compatibility with dbplyr 2.6.0 (#919).
-
-## fledge
-
-- CRAN release v1.2.1 (#898).
-
 ## Features
 
 - Enable `across()` translation for primitive functions such as `sum()` (#906, #907).
 
-## Chore
+## Compatibility
 
-- Add ccache to `.gitignore` and `.Rbuildignore`.
-
-- Auto-update from GitHub Actions (#913).
-
-- Auto-update from GitHub Actions (#902).
-
-- Auto-update from GitHub Actions (#900).
-
-## Continuous integration
-
-- Update ccache-action reference.
-
-- Bump action version.
-
-- Create snapshot update PR against correct branch.
-
-- Clarify rationale for not deploying on schedule.
-
-- Only run fledge on pushes to main.
-
-- Tweak fledge workflow and ccache action.
-
-- Cosmetics.
-
-- Bump action versions.
-
-- Install clang-format-21.
-
-- Align fledge workflow.
-
-- Harmonize.
-
-- Ignore failing test with duckdb 1.5.0.
+- `as_tbl()` attaches finalizer to `lazy_query`, not `tbl`, for compatibility with dbplyr 2.6.0 (#919).
 
 ## Documentation
 
 - Update Plausible analytics snippet (@jeroenjanssens, #910).
-
-## Uncategorized
-
-- Ci: Unify fledge.yaml across cynkratemplate and fledge (#86).
 
 
 # duckplyr 1.2.1 (2026-03-09)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,6 +2,6 @@ duckplyr 1.2.1.9900
 
 ## Cran Repository Policy
 
-- [ ] Reviewed CRP last edited 2026-05-31.
+- [x] Reviewed CRP last edited 2026-05-31.
 
 See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-05-31%7D

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,7 @@
-duckplyr 1.2.1
+duckplyr 1.2.1.9900
 
 ## Cran Repository Policy
 
-- [x] Reviewed CRP last edited 2026-02-20.
+- [ ] Reviewed CRP last edited 2026-05-31.
+
+See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-05-31%7D


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-06-17, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`