### PR TITLE
ci: Fix continuous benchmark (touchstone) workflow

### DIFF
--- a/.github/workflows/touchstone-comment.yaml
+++ b/.github/workflows/touchstone-comment.yaml
@@ -10,6 +10,13 @@ on:
     types:
       - completed
 
+permissions:
+  # `comment` posts the benchmark results as a PR comment and sets a commit
+  # status; the default read-only GITHUB_TOKEN cannot do either.
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   upload:
     runs-on: ubuntu-24.04

--- a/.github/workflows/touchstone-receive.yaml
+++ b/.github/workflows/touchstone-receive.yaml
@@ -26,3 +26,14 @@ jobs:
       - uses: lorenzwalthert/touchstone/actions/receive@main
         with:
           cache-version: 1
+          # Packages needed by the benchmark harness that aren't installed via
+          # the package's own dependencies:
+          # - qs2 is declared under Enhances (not installed by default) and is
+          #   used to cache the TPC-H tables (touchstone/script.R,
+          #   tools/31-tpch-load-qs.R).
+          # - pkgload and fs are undeclared but used by the data-generation
+          #   scripts (tools/30-tpch-export.R, tools/31-tpch-load-qs.R).
+          extra-packages: |
+            any::qs2
+            any::pkgload
+            any::fs

--- a/tools/31-tpch-load-qs.R
+++ b/tools/31-tpch-load-qs.R
@@ -11,13 +11,22 @@ tables <- c(
   "region"
 )
 
+# Materialize each table with `dplyr::collect()` before saving.
+# `read_parquet_duckdb()` returns a lazy, DuckDB-backed `duckplyr_df`.
+# qs2 can round-trip such an object, but it comes back as a materialized data
+# frame that still carries the `duckplyr_df` class and explicit row names.
+# The benchmark script then calls `as_duckdb_tibble()` on it, which fails with
+# "Need data frame without row names to convert to relational".
+# Collecting to a plain tibble up front avoids this.
 data <- lapply(tables, function(t) {
-  duckplyr::read_parquet_duckdb(
-    fs::path(
-      "tools/tpch/001",
-      paste0(t, ".parquet")
-    ),
-    prudence = "lavish"
+  dplyr::collect(
+    duckplyr::read_parquet_duckdb(
+      fs::path(
+        "tools/tpch/001",
+        paste0(t, ".parquet")
+      ),
+      prudence = "lavish"
+    )
   )
 })
 
@@ -29,12 +38,14 @@ qs2::qs_save(
 )
 
 data <- lapply(tables, function(t) {
-  duckplyr::read_parquet_duckdb(
-    fs::path(
-      "tools/tpch/010",
-      paste0(t, ".parquet")
-    ),
-    prudence = "lavish"
+  dplyr::collect(
+    duckplyr::read_parquet_duckdb(
+      fs::path(
+        "tools/tpch/010",
+        paste0(t, ".parquet")
+      ),
+      prudence = "lavish"
+    )
   )
 })
 
@@ -46,12 +57,14 @@ qs2::qs_save(
 )
 
 data <- lapply(tables, function(t) {
-  duckplyr::read_parquet_duckdb(
-    fs::path(
-      "tools/tpch/100",
-      paste0(t, ".parquet")
-    ),
-    prudence = "lavish"
+  dplyr::collect(
+    duckplyr::read_parquet_duckdb(
+      fs::path(
+        "tools/tpch/100",
+        paste0(t, ".parquet")
+      ),
+      prudence = "lavish"
+    )
   )
 })
 

--- a/tools/31-tpch-load-qs.R
+++ b/tools/31-tpch-load-qs.R
@@ -11,66 +11,39 @@ tables <- c(
   "region"
 )
 
-# Materialize each table with `dplyr::collect()` before saving.
-# `read_parquet_duckdb()` returns a lazy, DuckDB-backed `duckplyr_df`.
-# qs2 can round-trip such an object, but it comes back as a materialized data
-# frame that still carries the `duckplyr_df` class and explicit row names.
-# The benchmark script then calls `as_duckdb_tibble()` on it, which fails with
-# "Need data frame without row names to convert to relational".
-# Collecting to a plain tibble up front avoids this.
-data <- lapply(tables, function(t) {
-  dplyr::collect(
+scale_factors <- c("001", "010", "100")
+
+# Convert one table at a time, and give each table its own file.
+#
+# Collecting every table into a list before writing peaks at the size of the
+# whole dataset, which at scale factor 1 is dominated by `lineitem`.
+# Doing the work per table bounds peak memory by the largest single table
+# instead, and lets the benchmark load them the same way.
+#
+# `dplyr::collect()` materializes the lazy, DuckDB-backed `duckplyr_df` into a
+# plain tibble. Without it, qs2 stores an object that comes back carrying the
+# `duckplyr_df` class and explicit row names, and `as_duckdb_tibble()` then
+# aborts with "Need data frame without row names to convert to relational".
+convert_table <- function(sf, table) {
+  data <- dplyr::collect(
     duckplyr::read_parquet_duckdb(
-      fs::path(
-        "tools/tpch/001",
-        paste0(t, ".parquet")
-      ),
+      fs::path("tools/tpch", sf, paste0(table, ".parquet")),
       prudence = "lavish"
     )
   )
-})
 
-qs2::qs_save(
-  rlang::set_names(data, tables),
-  file = "tools/tpch/001.qs",
-  compress_level = 1,
-  shuffle = FALSE
-)
-
-data <- lapply(tables, function(t) {
-  dplyr::collect(
-    duckplyr::read_parquet_duckdb(
-      fs::path(
-        "tools/tpch/010",
-        paste0(t, ".parquet")
-      ),
-      prudence = "lavish"
-    )
+  qs2::qs_save(
+    data,
+    file = fs::path("tools/tpch", sf, paste0(table, ".qs")),
+    compress_level = 1,
+    shuffle = FALSE
   )
-})
+}
 
-qs2::qs_save(
-  rlang::set_names(data, tables),
-  file = "tools/tpch/010.qs",
-  compress_level = 1,
-  shuffle = FALSE
-)
-
-data <- lapply(tables, function(t) {
-  dplyr::collect(
-    duckplyr::read_parquet_duckdb(
-      fs::path(
-        "tools/tpch/100",
-        paste0(t, ".parquet")
-      ),
-      prudence = "lavish"
-    )
-  )
-})
-
-qs2::qs_save(
-  rlang::set_names(data, tables),
-  file = "tools/tpch/100.qs",
-  compress_level = 1,
-  shuffle = FALSE
-)
+for (sf in scale_factors) {
+  for (table in tables) {
+    convert_table(sf, table)
+    # Release the table before reading the next one.
+    gc()
+  }
+}

--- a/tools/70-touchstone-gen.R
+++ b/tools/70-touchstone-gen.R
@@ -19,17 +19,24 @@ body <- function(sf, test, n) {
     'benchmark_run(
   expr_before_benchmark = {{
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/{sf}.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {{
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/{sf}", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }}
   }},
   `{sf}_tpch_{test}` = collect(duckplyr:::tpch_{test}()),
   n = {n}

--- a/touchstone/script.R
+++ b/touchstone/script.R
@@ -10,17 +10,24 @@ branch_install()
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_01` = collect(duckplyr:::tpch_01()),
   n = 3
@@ -29,17 +36,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_02` = collect(duckplyr:::tpch_02()),
   n = 3
@@ -48,17 +62,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_03` = collect(duckplyr:::tpch_03()),
   n = 3
@@ -67,17 +88,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_04` = collect(duckplyr:::tpch_04()),
   n = 3
@@ -86,17 +114,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_05` = collect(duckplyr:::tpch_05()),
   n = 3
@@ -105,17 +140,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_06` = collect(duckplyr:::tpch_06()),
   n = 3
@@ -124,17 +166,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_07` = collect(duckplyr:::tpch_07()),
   n = 3
@@ -143,17 +192,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_08` = collect(duckplyr:::tpch_08()),
   n = 3
@@ -162,17 +218,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_09` = collect(duckplyr:::tpch_09()),
   n = 3
@@ -181,17 +244,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_10` = collect(duckplyr:::tpch_10()),
   n = 3
@@ -200,17 +270,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_11` = collect(duckplyr:::tpch_11()),
   n = 3
@@ -219,17 +296,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_12` = collect(duckplyr:::tpch_12()),
   n = 3
@@ -238,17 +322,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_13` = collect(duckplyr:::tpch_13()),
   n = 3
@@ -257,17 +348,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_14` = collect(duckplyr:::tpch_14()),
   n = 3
@@ -276,17 +374,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_15` = collect(duckplyr:::tpch_15()),
   n = 3
@@ -295,17 +400,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_16` = collect(duckplyr:::tpch_16()),
   n = 3
@@ -314,17 +426,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_17` = collect(duckplyr:::tpch_17()),
   n = 3
@@ -333,17 +452,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_18` = collect(duckplyr:::tpch_18()),
   n = 3
@@ -352,17 +478,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_19` = collect(duckplyr:::tpch_19()),
   n = 3
@@ -371,17 +504,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_20` = collect(duckplyr:::tpch_20()),
   n = 3
@@ -390,17 +530,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_21` = collect(duckplyr:::tpch_21()),
   n = 3
@@ -409,17 +556,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/100.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/100", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `100_tpch_22` = collect(duckplyr:::tpch_22()),
   n = 3
@@ -428,17 +582,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_01` = collect(duckplyr:::tpch_01()),
   n = 10
@@ -447,17 +608,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_02` = collect(duckplyr:::tpch_02()),
   n = 10
@@ -466,17 +634,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_03` = collect(duckplyr:::tpch_03()),
   n = 10
@@ -485,17 +660,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_04` = collect(duckplyr:::tpch_04()),
   n = 10
@@ -504,17 +686,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_05` = collect(duckplyr:::tpch_05()),
   n = 10
@@ -523,17 +712,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_06` = collect(duckplyr:::tpch_06()),
   n = 10
@@ -542,17 +738,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_07` = collect(duckplyr:::tpch_07()),
   n = 10
@@ -561,17 +764,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_08` = collect(duckplyr:::tpch_08()),
   n = 10
@@ -580,17 +790,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_09` = collect(duckplyr:::tpch_09()),
   n = 10
@@ -599,17 +816,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_10` = collect(duckplyr:::tpch_10()),
   n = 10
@@ -618,17 +842,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_11` = collect(duckplyr:::tpch_11()),
   n = 10
@@ -637,17 +868,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_12` = collect(duckplyr:::tpch_12()),
   n = 10
@@ -656,17 +894,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_13` = collect(duckplyr:::tpch_13()),
   n = 10
@@ -675,17 +920,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_14` = collect(duckplyr:::tpch_14()),
   n = 10
@@ -694,17 +946,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_15` = collect(duckplyr:::tpch_15()),
   n = 10
@@ -713,17 +972,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_16` = collect(duckplyr:::tpch_16()),
   n = 10
@@ -732,17 +998,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_17` = collect(duckplyr:::tpch_17()),
   n = 10
@@ -751,17 +1024,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_18` = collect(duckplyr:::tpch_18()),
   n = 10
@@ -770,17 +1050,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_19` = collect(duckplyr:::tpch_19()),
   n = 10
@@ -789,17 +1076,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_20` = collect(duckplyr:::tpch_20()),
   n = 10
@@ -808,17 +1102,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_21` = collect(duckplyr:::tpch_21()),
   n = 10
@@ -827,17 +1128,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/010.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/010", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `010_tpch_22` = collect(duckplyr:::tpch_22()),
   n = 10
@@ -846,17 +1154,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_01` = collect(duckplyr:::tpch_01()),
   n = 30
@@ -865,17 +1180,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_02` = collect(duckplyr:::tpch_02()),
   n = 30
@@ -884,17 +1206,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_03` = collect(duckplyr:::tpch_03()),
   n = 30
@@ -903,17 +1232,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_04` = collect(duckplyr:::tpch_04()),
   n = 30
@@ -922,17 +1258,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_05` = collect(duckplyr:::tpch_05()),
   n = 30
@@ -941,17 +1284,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_06` = collect(duckplyr:::tpch_06()),
   n = 30
@@ -960,17 +1310,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_07` = collect(duckplyr:::tpch_07()),
   n = 30
@@ -979,17 +1336,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_08` = collect(duckplyr:::tpch_08()),
   n = 30
@@ -998,17 +1362,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_09` = collect(duckplyr:::tpch_09()),
   n = 30
@@ -1017,17 +1388,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_10` = collect(duckplyr:::tpch_10()),
   n = 30
@@ -1036,17 +1414,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_11` = collect(duckplyr:::tpch_11()),
   n = 30
@@ -1055,17 +1440,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_12` = collect(duckplyr:::tpch_12()),
   n = 30
@@ -1074,17 +1466,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_13` = collect(duckplyr:::tpch_13()),
   n = 30
@@ -1093,17 +1492,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_14` = collect(duckplyr:::tpch_14()),
   n = 30
@@ -1112,17 +1518,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_15` = collect(duckplyr:::tpch_15()),
   n = 30
@@ -1131,17 +1544,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_16` = collect(duckplyr:::tpch_16()),
   n = 30
@@ -1150,17 +1570,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_17` = collect(duckplyr:::tpch_17()),
   n = 30
@@ -1169,17 +1596,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_18` = collect(duckplyr:::tpch_18()),
   n = 30
@@ -1188,17 +1622,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_19` = collect(duckplyr:::tpch_19()),
   n = 30
@@ -1207,17 +1648,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_20` = collect(duckplyr:::tpch_20()),
   n = 30
@@ -1226,17 +1674,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_21` = collect(duckplyr:::tpch_21()),
   n = 30
@@ -1245,17 +1700,24 @@ benchmark_run(
 benchmark_run(
   expr_before_benchmark = {
     library(duckplyr)
-    data <- qs2::qs_read("tools/tpch/001.qs")
-    .mapply(assign, list(names(data), data), list(pos = .GlobalEnv))
-
-    customer <- as_duckdb_tibble(customer)
-    lineitem <- as_duckdb_tibble(lineitem)
-    nation <- as_duckdb_tibble(nation)
-    orders <- as_duckdb_tibble(orders)
-    part <- as_duckdb_tibble(part)
-    partsupp <- as_duckdb_tibble(partsupp)
-    region <- as_duckdb_tibble(region)
-    supplier <- as_duckdb_tibble(supplier)
+    for (table in c(
+      "customer",
+      "lineitem",
+      "nation",
+      "orders",
+      "part",
+      "partsupp",
+      "region",
+      "supplier"
+    )) {
+      assign(
+        table,
+        as_duckdb_tibble(
+          qs2::qs_read(file.path("tools/tpch/001", paste0(table, ".qs")))
+        ),
+        envir = .GlobalEnv
+      )
+    }
   },
   `001_tpch_22` = collect(duckplyr:::tpch_22()),
   n = 30


### PR DESCRIPTION
The continuous benchmark workflow could not run to completion. Three independent issues, all fixed here:

- `touchstone/script.R` and its data-generation helpers use `qs2`, `pkgload`, and `fs`, but the `receive` action never installs them. `qs2` is declared under `Enhances` (not installed by default) and `pkgload`/`fs` are undeclared, so `qs2::qs_read()` and the data-prep scripts fail. Install them via `extra-packages`.

- `tools/31-tpch-load-qs.R` cached the TPC-H tables as lazy, DuckDB-backed `duckplyr_df` objects. qs2 round-trips them into materialized frames that keep the `duckplyr_df` class and explicit row names, so the benchmark's `as_duckdb_tibble()` aborts with "Need data frame without row names to convert to relational". Collect to plain tibbles before saving.

- The `comment` workflow posts a PR comment and sets a commit status but declared no permissions, which fails under a read-only default `GITHUB_TOKEN`. Grant `pull-requests: write` and `statuses: write`.

Verified locally end to end: generate scale-factor TPC-H data, cache via qs2, reload, convert with `as_duckdb_tibble()`, and run all 22 TPC-H benchmark queries.


Claude-Session: https://claude.ai/code/session_011X3BjyMVghj28LNsZFPbG8